### PR TITLE
Adding default gtk theme settings

### DIFF
--- a/dotfiles/gtk-2.0/gtkrc-2.0
+++ b/dotfiles/gtk-2.0/gtkrc-2.0
@@ -1,0 +1,18 @@
+# DO NOT EDIT! This file will be overwritten by LXAppearance.
+# Any customization should be done in ~/.gtkrc-2.0.mine instead.
+
+gtk-theme-name="Nordic"
+gtk-icon-theme-name="Papirus-Dark"
+gtk-font-name="Sans 10"
+gtk-cursor-theme-name="Adwaita"
+gtk-cursor-theme-size=0
+gtk-toolbar-style=GTK_TOOLBAR_ICONS
+gtk-toolbar-icon-size=GTK_ICON_SIZE_LARGE_TOOLBAR
+gtk-button-images=1
+gtk-menu-images=1
+gtk-enable-event-sounds=1
+gtk-enable-input-feedback-sounds=1
+gtk-xft-antialias=1
+gtk-xft-hinting=1
+gtk-xft-hintstyle="hintfull"
+gtk-xft-rgba="rgb"

--- a/dotfiles/gtk-3.0/gtk.css
+++ b/dotfiles/gtk-3.0/gtk.css
@@ -1,0 +1,14 @@
+VteTerminal, vte-terminal {
+    padding: 15px;
+}
+
+.window-frame, .window-frame:backdrop {
+  box-shadow: 0 0 0 black;
+  border-style: none;
+  margin: 0;
+  border-radius: 0;
+}
+    
+.titlebar {
+  border-radius: 0;
+}

--- a/dotfiles/gtk-3.0/settings.ini
+++ b/dotfiles/gtk-3.0/settings.ini
@@ -1,0 +1,18 @@
+[Settings]
+gtk-application-prefer-dark-theme=true
+gtk-enable-animations=true
+gtk-font-name=Sans 10
+gtk-icon-theme-name=Papirus-Dark
+gtk-theme-name=Nordic
+gtk-cursor-theme-name=Adwaita
+gtk-cursor-theme-size=0
+gtk-toolbar-style=GTK_TOOLBAR_ICONS
+gtk-toolbar-icon-size=GTK_ICON_SIZE_LARGE_TOOLBAR
+gtk-button-images=1
+gtk-menu-images=1
+gtk-enable-event-sounds=1
+gtk-enable-input-feedback-sounds=1
+gtk-xft-antialias=1
+gtk-xft-hinting=1
+gtk-xft-hintstyle=hintfull
+gtk-xft-rgba=rgb


### PR DESCRIPTION
This sets the Nordic GTK theme and Papirus-Dark icon theme by default. The user can change it later if they want in lxappearance.