### PR TITLE
Icon padding fix in xwindow and eth module

### DIFF
--- a/dotfiles/polybar/config
+++ b/dotfiles/polybar/config
@@ -290,7 +290,7 @@ label-maxlen = 120
 label-empty = Desktop
 
 format = <label>
-format-prefix = ""
+format-prefix = "" "
 format-prefix-foreground = ${colors.shade14}
 format-foreground = ${colors.shade14}
 ;format-background = ${colors.shade16}

--- a/dotfiles/polybar/config
+++ b/dotfiles/polybar/config
@@ -546,7 +546,7 @@ interface = enp5s0
 interval = 3.0
 
 ;format-connected-underline = ${xrdb:color2}
-format-connected-prefix = ""
+format-connected-prefix = " "
 format-connected-background = ${colors.shade16}
 ;format-connected-padding = 1
 format-connected-prefix-foreground = ${colors.shade5}

--- a/dotfiles/polybar/config
+++ b/dotfiles/polybar/config
@@ -290,7 +290,7 @@ label-maxlen = 120
 label-empty = Desktop
 
 format = <label>
-format-prefix = "" "
+format-prefix = " "
 format-prefix-foreground = ${colors.shade14}
 format-foreground = ${colors.shade14}
 ;format-background = ${colors.shade16}


### PR DESCRIPTION
The icon in module xwindow and eth didn't have any padding next to the text, simple fix.