### PR TITLE
Fixing the original nord theme for Rofi 1.7.0 refs #26

### DIFF
--- a/dotfiles/rofi/themes/nord.rasi
+++ b/dotfiles/rofi/themes/nord.rasi
@@ -6,21 +6,6 @@
  *
  */
 
-configuration {
-
-	font: "Envy Code R 10";
-	width: 30;
-	line-margin: 10;
-	lines: 6;
-	columns: 2;
-
-    display-ssh:    "";
-    display-run:    "";
-    display-drun:   "";
-    display-window: "";
-    display-combi:  "";
-    show-icons:     true;
-}
 
 * {
 	nord0: #2e3440;
@@ -46,20 +31,20 @@ configuration {
     foreground:  @nord9;
     backlight:   #ccffeedd;
     background-color:  transparent;
-    
+
     highlight:     underline bold #eceff4;
 
     transparent: rgba(46,52,64,0);
 }
 
 window {
-	location:	 west;
-	anchor:		 west;
+    location: center;
+    anchor:   center;
     transparency: "screenshot";
     padding: 10px;
     border:  0px;
     border-radius: 6px;
-    sidebar-mode:    true;
+
     background-color: @transparent;
     spacing: 0;
     children:  [mainbox];
@@ -95,7 +80,7 @@ entry, prompt, case-indicator {
 }
 
 prompt {
-    margin: 0px 0.3em 0em 0em ;
+    margin: 0px 1em 0em 0em ;
 }
 
 listview {


### PR DESCRIPTION
refs #26 

Original PR: https://github.com/undiabler/nord-rofi-theme/pull/2

For Rofi 1.7.0 the original nord.rasi in the dotfiles is broken. This PR fixes that problem.

The `configuration` part of the theme was moved to the config of Rofi.

In the readme of the PR it says:
(edit: added the `themes` part, so we're copying it to the right place and getting the theme from the right place)

1. Copy <a href="nord.rasi">nord.rasi</a> file to `~/.config/rofi/themes/nord.rasi`
2. Add the following lines to your rofi config (`~/.config/rofi/config.rasi`):
```
configuration {
    font: "Envy Code R 10";
    width: 30;
    line-margin: 10;
    lines: 6;
    columns: 2;
    display-ssh:    "";
    display-run:    "";
    display-drun:   "";
    display-window: "";
    display-combi:  "";
    show-icons:     true;
}
@theme "~/.config/rofi/themes/nord.rasi"
```