### PR TITLE
Fix URL for debian testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ _This install changes Debian to the SID (Dev) Branch_
 
 ### Download Debian Testing netinstall
 
-Use the following Debian ISO as the base [<https://cdimage.debian.org/cdimage/weekly-builds/amd64/iso-cd/>](https://cdimage.debian.org/cdimage/weekly-builds/amd64/iso-cd/)
+Use the following Debian ISO as the base <https://cdimage.debian.org/cdimage/weekly-builds/amd64/iso-cd/>
 
 *do NOT grab the mac/EDU download and this includes non-free firmware*
 ### To install:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Debian customizations from Chris Titus Tech
 ## Requirements
 _This install changes Debian to the SID (Dev) Branch_
 
-### Download Debian non-free netinstall
+### Download Debian Testing netinstall
 
 Use the following Debian ISO as the base [<https://cdimage.debian.org/cdimage/weekly-builds/amd64/iso-cd/>](https://cdimage.debian.org/cdimage/weekly-builds/amd64/iso-cd/)
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ _This install changes Debian to the SID (Dev) Branch_
 
 ### Download Debian non-free netinstall
 
-Use the following Debian ISO as the base [<https://cdimage.debian.org/cdimage/unofficial/non-free/cd-including-firmware/weekly-builds/amd64/iso-cd/>](https://cdimage.debian.org/cdimage/unofficial/non-free/cd-including-firmware/current/amd64/iso-cd/)
+Use the following Debian ISO as the base [<https://cdimage.debian.org/cdimage/weekly-builds/amd64/iso-cd/>](https://cdimage.debian.org/cdimage/weekly-builds/amd64/iso-cd/)
 
-*do NOT grab the EDU download and this includes non-free and firmware*
+*do NOT grab the mac/EDU download and this includes non-free firmware*
 ### To install:
 
 ```


### PR DESCRIPTION
Debian testing now includes non-free firmware in the image

The older URL is now invalid 