### PR TITLE
Import .use-nala files instead of adding their code to bashrc files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -79,33 +79,6 @@ sudo nala install brave-browser -y
 systemctl enable sddm
 systemctl set-default graphical.target
 
-# Configure bash to use nala wrapper instead of apt
-ubashrc="/home/$username/.bashrc"
-rbashrc="/root/.bashrc"
-if [ -f "$ubashrc" ]; then
-cat << \EOF >> "$ubashrc"
-apt() {
-  command nala "$@"
-}
-sudo() {
-  if [ "$1" = "apt" ]; then
-    shift
-    command sudo nala "$@"
-  else
-    command sudo "$@"
-  fi
-}
-EOF
-fi
-
-if [ -f "$rbashrc" ]; then
-cat << \EOF >> "$rbashrc"
-apt() {
-  command nala "$@"
-}
-EOF
-fi
-
 # Beautiful bash
 git clone https://github.com/ChrisTitusTech/mybash
 cd mybash
@@ -115,3 +88,5 @@ cd $builddir
 # Polybar configuration
 bash scripts/changeinterface
 
+# Use nala
+bash scripts/usenala

--- a/scripts/usenala
+++ b/scripts/usenala
@@ -1,0 +1,40 @@
+#!/bin/bash
+username=$(id -u -n 1000)
+# Configure bash to use nala wrapper instead of apt
+usenala="/home/$username/.use-nala"
+rusenala="/root/.use-nala"
+ubashrc="/home/$username/.bashrc"
+rbashrc="/root/.bashrc"
+if [ ! -f "$usenala" ]; then
+cat << \EOF > "$usenala"
+apt() {
+  command nala "$@"
+}
+sudo() {
+  if [ "$1" = "apt" ]; then
+    shift
+    command sudo nala "$@"
+  else
+    command sudo "$@"
+  fi
+}
+EOF
+cat << EOF >> "$ubashrc"
+if [ -f "$usenala" ]; then
+        . "$usenala"
+fi
+EOF
+fi
+
+if [ ! -f "$rusenala" ]; then
+cat << \EOF > "$rusenala"
+apt() {
+  command nala "$@"
+}
+EOF
+cat << EOF >> "$rbashrc"
+if [ -f "$rusenala" ]; then
+        . "$rusenala"
+fi
+EOF
+fi


### PR DESCRIPTION
also made it a seperate script to prevent bloating the install script.

While testing my changes, I got my `.bashrc` overwrited cause i forgot to add one more `>` :smile: 
Luckily I was opened `~/.bashrc` in nano on another terminal tab before getting it overwrited.

I think importing .use-nala is a good idea because if someone run the install script more than once, `.bashrc` can get messed up.

Old code was adding the code to `.bashrc` that configures bash to use nala in every time install script is ran and this was not good. Now, it'll check existence of `.use-nala` file and it will not re-add the code to `.bashrc` if it exists.

```
# For User
$ cat .use-nala 
apt() {
  command nala "$@"
}
sudo() {
  if [ "$1" = "apt" ]; then
    shift
    command sudo nala "$@"
  else
    command sudo "$@"
  fi
}

$ cat ~/.bashrc
...
if [ -f "/home/nxjoseph/.use-nala" ]; then
        . "/home/nxjoseph/.use-nala"
fi

# For Root
# cat ~/.use-nala
apt() {
  command nala "$@"
}

# cat ~/.bashrc 
...
if [ -f "/root/.use-nala" ]; then
        . "/root/.use-nala"
fi
```