### PR TITLE
Remove sudo from commands that contains sudo in installation script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -69,11 +69,11 @@ cd $builddir
 rm -rf Nordzy-cursors
 
 # Install brave-browser
-sudo nala install apt-transport-https curl -y
-sudo curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
-echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main" | sudo tee /etc/apt/sources.list.d/brave-browser-release.list
-sudo nala update
-sudo nala install brave-browser -y
+nala install apt-transport-https curl -y
+curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main" | tee /etc/apt/sources.list.d/brave-browser-release.list
+nala update
+nala install brave-browser -y
 
 # Enable graphical login and change target from CLI to GUI
 systemctl enable sddm


### PR DESCRIPTION
I think sudo is not needed because you must be a root user to run this script.