### PR TITLE
add bat to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,7 @@ chown -R $username:$username /home/$username
 # Installing Essential Programs 
 nala install feh kitty rofi picom thunar nitrogen lxpolkit x11-xserver-utils unzip wget pulseaudio pavucontrol build-essential libx11-dev libxft-dev libxinerama-dev -y
 # Installing Other less important Programs
-nala install neofetch flameshot psmisc mangohud vim lxappearance papirus-icon-theme lxappearance fonts-noto-color-emoji lightdm -y
+nala install neofetch flameshot psmisc mangohud vim lxappearance papirus-icon-theme lxappearance fonts-noto-color-emoji lightdm bat -y
 
 # Download Nordic Theme
 cd /usr/share/themes/


### PR DESCRIPTION
Adding bat package to install script since beautiful bash has an alias to replace cat with batcat essentially breaking cat if not installed.
See:
https://github.com/ChrisTitusTech/mybash/blob/2ea1210f2aee6146ea80e4ff8854f2d466ae28dd/.bashrc#L59